### PR TITLE
Add speed and growth game modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-# Red-Panda
+# Red Panda
+
+## Usage
+
+```bash
+python main.py --mode speed   # velocidad creciente, sin cola
+python main.py --mode growth  # modo clásico, la serpiente crece
+```


### PR DESCRIPTION
## Summary
- add GameMode enum and CLI flag to switch between SPEED and GROWTH modes
- handle snake body, growth, and HUD display for GROWTH mode
- document new mode options in README

## Testing
- `python -m py_compile main.py`
- `python main.py --help`


------
https://chatgpt.com/codex/tasks/task_e_689654892a448327970cdf62d66fd3cc